### PR TITLE
Using AVX512 compress instruction to boost select on unpacked data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.claude

--- a/benches/bit_pack_bench.rs
+++ b/benches/bit_pack_bench.rs
@@ -1,4 +1,4 @@
-use bmi_select::{BitPackable, bit_pack, bit_unpack, select_packed};
+use bmi_select::{BitPackable, bit_pack, bit_unpack, select_packed, select_unpacked};
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use fastlanes::BitPacking as FLBitPacking;
 
@@ -180,18 +180,24 @@ fn bench_select_packed_selection_ratios(c: &mut Criterion) {
         // Benchmark our implementation
         group.bench_with_input(
             BenchmarkId::new("bmi_select", format!("{ratio_percent}%")),
-            &(packed_data.clone(), bit_mask),
+            &(packed_data.clone(), bit_mask.clone()),
             |b, (packed, mask)| {
                 let selected_count = mask_data.iter().sum::<u64>() as usize;
                 let selected_bits = selected_count * bit_width;
-                let mut out = vec![0u64; selected_bits.div_ceil(64)];
+                let mut packed_selected = vec![0u64; selected_bits.div_ceil(64)];
+                // let mut unpacked_selected = vec![0u64; selected_count];
                 b.iter(|| {
                     select_packed(
                         black_box(packed),
                         black_box(bit_width),
                         black_box(mask),
-                        black_box(&mut out),
-                    )
+                        black_box(&mut packed_selected),
+                    );
+                    // bit_unpack(
+                    //     black_box(&packed_selected),
+                    //     black_box(bit_width),
+                    //     black_box(&mut unpacked_selected),
+                    // )
                 })
             },
         );
@@ -233,6 +239,55 @@ fn bench_select_packed_selection_ratios(c: &mut Criterion) {
 
                     // Repack selected values
                     let num_selected = selected.len();
+                    let out_batches = num_selected.div_ceil(1024);
+                    repacked.clear();
+                    repacked.resize(out_batches * out_batch, 0u64);
+
+                    for j in 0..out_batches {
+                        let start = j * 1024;
+                        let end = usize::min(start + 1024, num_selected);
+                        tmp_input[..end - start].copy_from_slice(&selected[start..end]);
+                        for v in &mut tmp_input[end - start..] {
+                            *v = 0;
+                        }
+                        unsafe {
+                            FLBitPacking::unchecked_pack(
+                                bit_width,
+                                &tmp_input,
+                                &mut repacked[j * out_batch..(j + 1) * out_batch],
+                            );
+                        }
+                    }
+                })
+            },
+        );
+
+        // Benchmark fastlanes no-branch implementation
+        group.bench_function(
+            BenchmarkId::new("fastlanes-avx512-select", format!("{ratio_percent}%")),
+            |b| {
+                let mut unpacked = vec![0u64; size];
+                let mut selected = vec![0u64; size];
+                let mut tmp_input = vec![0u64; 1024];
+                let mut repacked = Vec::<u64>::new();
+
+                b.iter(|| {
+                    // Unpack data
+                    for i in 0..batches {
+                        unsafe {
+                            FLBitPacking::unchecked_unpack(
+                                bit_width,
+                                &fl_packed_data[i * out_batch..(i + 1) * out_batch],
+                                &mut unpacked[i * 1024..(i + 1) * 1024],
+                            );
+                        }
+                    }
+
+                    // Select values based on mask_bm
+                    let selected_idx = select_unpacked(&unpacked, &bit_mask, &mut selected, size);
+
+                    // Repack selected values
+                    let num_selected = selected_idx;
                     let out_batches = num_selected.div_ceil(1024);
                     repacked.clear();
                     repacked.resize(out_batches * out_batch, 0u64);

--- a/benches/bit_pack_bench.rs
+++ b/benches/bit_pack_bench.rs
@@ -262,7 +262,7 @@ fn bench_select_packed_selection_ratios(c: &mut Criterion) {
             },
         );
 
-        // Benchmark fastlanes no-branch implementation
+        // Benchmark fastlanes implementation with avx512 select
         group.bench_function(
             BenchmarkId::new("fastlanes-avx512-select", format!("{ratio_percent}%")),
             |b| {
@@ -283,7 +283,7 @@ fn bench_select_packed_selection_ratios(c: &mut Criterion) {
                         }
                     }
 
-                    // Select values based on mask_bm
+                    // Select values based on bit_mask
                     let selected_idx = select_unpacked(&unpacked, &bit_mask, &mut selected, size);
 
                     // Repack selected values

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,4 @@ mod pack_unpack;
 mod select;
 pub use pack_unpack::{BitPackable, bit_pack, bit_unpack};
 pub use select::select_packed;
+pub use select::select_unpacked;

--- a/src/select.rs
+++ b/src/select.rs
@@ -506,8 +506,8 @@ fn select_unpacked_fallback(src: &[u64], bitmap: &[u64], dst: &mut [u64], n: usi
     let mut src_idx = 0;
     let num_full_chunks = n / 64;
 
-    for i in 0..num_full_chunks {
-        let mut current_bitmap = bitmap[i];
+    for (_i, &current_bitmap) in bitmap.iter().enumerate().take(num_full_chunks) {
+        let mut current_bitmap = current_bitmap;
         // This loop of 64 is branch-free for selection.
         for _ in 0..64 {
             dst[selected_idx] = src[src_idx];
@@ -576,9 +576,7 @@ unsafe fn select_unpacked_avx512_compress(
             let masks = slice::from_raw_parts(bitmap_ptr as *const u8, NUM_ROUNDS_IN_A_BATCH);
 
             // Process 16 rounds of 8 elements each
-            for j in 0..NUM_ROUNDS_IN_A_BATCH {
-                let mask = masks[j];
-
+            for (_j, &mask) in masks.iter().enumerate().take(NUM_ROUNDS_IN_A_BATCH) {
                 // Load 8 elements and compress using mask
                 let src_v = _mm512_loadu_epi64(src_ptr as *const i64);
                 let dst_v = _mm512_maskz_compress_epi64(mask, src_v);


### PR DESCRIPTION
Back in the day, @Sweetlemon68 and I wanted to know when doing selection pushdown, between the bmi-select approach and Fastlanes' vectorized approach, which one is better, so we implemented both in C++. Our conclusion at that time is that FastLanes is always better as long as the bitwidth is greater than 3-5. So it is interesting to me in this repo that bmi-select can be 2x better. 

Digging deeper, it seems that the select operation on unpacked data in the "select_packed/fastlanes" bench is unoptimized. So I added the similar (actually reverse, expand becomes compress) trick in Listing 1 of the [NULLS! paper](https://dl.acm.org/doi/10.1145/3662010.3663452). After that, the fastlanes-select is on par with bmi-select. If we assume the output data is unpacked, fastlanes-select is always better, which is also our previous experiment setup.

@Sweetlemon68 may open source the C++ bmi select code later.
Also, given that bmi2 was released in 2013 and avx512f was in 2016, I think it may be fair if we use non-scalar code for both select on packed and unpacked data.

@XiangpengHao 