### PR TITLE
fix: compile for non-x86

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: '-A warnings -Z sanitizer=address'
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      RUSTFLAGS: '-A warnings -Z sanitizer=address'
+      RUSTFLAGS: '-Z sanitizer=address'
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,9 +195,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "fastlanes"
-version = "0.1.8"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0504746b2d3b8249642d675325a6de910351f5aefc909a08450b2e239b169fd2"
+checksum = "f9504b2eddaa58bb69cf825baa2f46c4e97a5891dd1f167eab788d9c22692aa5"
 dependencies = [
  "arrayref",
  "const_for",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ seq-macro = "0.3.6"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
-fastlanes = "0.1.8"
+fastlanes = "0.2.0"
 
 [[bench]]
 name = "bit_pack_bench"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly"
+channel = "1.88.0"
 components = ["rustfmt", "rust-analyzer"]


### PR DESCRIPTION
Fixes compile errors from non-AVX hardware (in this case, my Apple Silicon machine).

Also add flags to run unit tests with AddressSanitizer, which I think is helpful for making sure there are no unsafe memory accesses triggered by the AVX512 load/stores (I recently added this to the Vortex CI job for this reason https://github.com/vortex-data/vortex/pull/3801)